### PR TITLE
Allow giving a connection rather than an address

### DIFF
--- a/kanin/src/app.rs
+++ b/kanin/src/app.rs
@@ -128,7 +128,7 @@ impl App {
 
     /// Runs the app with all the handlers that have been registered.
     ///
-    /// Each handler is given its own dedicated channel associated with the single connection created from the provided connection.
+    /// Each handler is given its own dedicated channel associated with the given connection.
     /// The handlers then run in their own spawned tokio tasks.
     /// Handlers handle requests concurrently by spawning new tokio tasks for each incoming request.
     ///

--- a/kanin/src/lib.rs
+++ b/kanin/src/lib.rs
@@ -28,6 +28,8 @@
 
 // Re-exporting underlying lapin version so you don't have to add the same version as a dependency.
 pub use lapin;
+// Also re-exporting connection for easy access.
+pub use lapin::Connection;
 
 pub mod app;
 pub mod derive;

--- a/kanin/src/tests/send_recv.rs
+++ b/kanin/src/tests/send_recv.rs
@@ -11,7 +11,7 @@ use crate::{
     Respond,
 };
 
-use super::{amqp_connect, TEST_AMQP_ADDR};
+use super::amqp_connect;
 
 #[derive(Debug)]
 struct MyResponse(String);
@@ -112,7 +112,7 @@ async fn it_receives_various_messages_and_works_as_expected() {
         .handler("handler_state_extractor", handler_state_extractor)
         .handler("listener", listener)
         .handler("shutdown", shutdown)
-        .setup_handlers(TEST_AMQP_ADDR)
+        .setup_handlers(&amqp_connect().await)
         .await
         .unwrap();
 
@@ -121,7 +121,7 @@ async fn it_receives_various_messages_and_works_as_expected() {
         .handler("handler_reply_to", handler)
         .handler("handler_message_reply_to", handler_message)
         .handler("recv_shutdown", shutdown)
-        .setup_handlers(TEST_AMQP_ADDR)
+        .setup_handlers(&amqp_connect().await)
         .await
         .unwrap();
 


### PR DESCRIPTION
It's useful to be able to tell Kanin to use a specific connection.

Specifically this comes from needing to have state that is initialized using a connection.

I know Lapin is exposed, but
```rs
let conn = App::create_connection("...").await?;
```
looks better (and is easier to find) than
```rs
let conn = App::lapin::Connection::connect("...", App::lapin::ConnectionProperties::default()).await?;
```