### PR TITLE
Impl Extract for Acker

### DIFF
--- a/kanin/Cargo.toml
+++ b/kanin/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "kanin"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2021"
 authors = ["Victor Nordam Suadicani <v.n.suadicani@gmail.com>"]
 description = "An RPC microservice framework for AMQP, protobuf and Rust built on lapin (https://github.com/amqp-rs/lapin)."
-rust-version = "1.60"
+rust-version = "1.62"
 repository = "https://github.com/issuu/kanin"
 license = "MIT OR Apache-2.0"
 readme = "../README.md"

--- a/kanin/src/extract.rs
+++ b/kanin/src/extract.rs
@@ -13,7 +13,10 @@ use crate::{error::HandlerError, Request};
 pub use message::Msg;
 pub use state::State;
 
-/// A trait for types that can be extracted from requests.
+/// A trait for types that can be extracted from [requests](`Request`).
+///
+/// Note that extractions might mutate the request in certain ways.
+/// Most notably, if extracting the [`Delivery`] or [`Acker`] from a request, it is the responsibility of the handler to acknowledge the message.
 #[async_trait]
 pub trait Extract: Sized {
     /// The error to return in case extraction fails.
@@ -23,6 +26,8 @@ pub trait Extract: Sized {
     async fn extract(req: &mut Request) -> Result<Self, Self::Error>;
 }
 
+/// Note that when you extract the [`Delivery`], the handler itself must acknowledge the request.
+/// Kanin *will not* acknowledge the request for you in this case.
 #[async_trait]
 impl Extract for Delivery {
     type Error = HandlerError;
@@ -34,6 +39,8 @@ impl Extract for Delivery {
     }
 }
 
+/// Note that when you extract the [`Acker`], the handler itself must acknowledge the request.
+/// kanin *will not* acknowledge the request for you in this case.
 #[async_trait]
 impl Extract for Acker {
     type Error = HandlerError;

--- a/kanin/src/extract/message.rs
+++ b/kanin/src/extract/message.rs
@@ -19,7 +19,7 @@ where
     type Error = HandlerError;
 
     async fn extract(req: &mut Request) -> Result<Self, Self::Error> {
-        match req.delivery() {
+        match &req.delivery {
             None => Err(HandlerError::DELIVERY_ALREADY_EXTRACTED),
             Some(d) => {
                 let data: &[u8] = &d.data;

--- a/kanin/src/request.rs
+++ b/kanin/src/request.rs
@@ -16,7 +16,7 @@ pub struct Request {
     /// The channel the message was received on.
     channel: Channel,
     /// The message delivery.
-    delivery: Option<Delivery>,
+    pub(crate) delivery: Option<Delivery>,
 }
 
 impl Request {
@@ -38,18 +38,6 @@ impl Request {
     /// Returns a reference to the [`Channel`] the message was delivered on.
     pub fn channel(&self) -> &Channel {
         &self.channel
-    }
-
-    /// Returns a reference to the [`Delivery`] of the request.
-    ///
-    /// The delivery may be `None` if it was consumed by a request.
-    pub fn delivery(&self) -> Option<&Delivery> {
-        self.delivery.as_ref()
-    }
-
-    /// Takes the request's [`Delivery`] out of the request and leaves the Delivery blank.
-    pub fn take_delivery(&mut self) -> Option<Delivery> {
-        self.delivery.take()
     }
 
     /// Returns the queue that reply messages should be sent to.

--- a/kanin/src/tests/send_recv.rs
+++ b/kanin/src/tests/send_recv.rs
@@ -36,7 +36,7 @@ impl Extract for MyResponse {
     type Error = HandlerError;
 
     async fn extract(req: &mut Request) -> Result<Self, Self::Error> {
-        match req.delivery() {
+        match &req.delivery {
             None => Err(HandlerError::DELIVERY_ALREADY_EXTRACTED),
             Some(d) => Ok(MyResponse(String::from_utf8_lossy(&d.data).to_string())),
         }


### PR DESCRIPTION
Makes it possible to extract a lapin acker for use in handlers. This means that it becomes the handler's responsibility to acknowledge however!