### PR TITLE
Add durable and exchange to QueueConfig

### DIFF
--- a/kanin/Cargo.toml
+++ b/kanin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanin"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 authors = ["Victor Nordam Suadicani <v.n.suadicani@gmail.com>"]
 description = "An RPC microservice framework for AMQP, protobuf and Rust built on lapin (https://github.com/amqp-rs/lapin)."

--- a/kanin/src/app/task.rs
+++ b/kanin/src/app/task.rs
@@ -11,12 +11,9 @@ use lapin::{
 };
 use log::{debug, error, warn};
 
-use crate::{Handler, QueueConfig, Request, Respond};
+use crate::{queue_config::Exchange, Handler, QueueConfig, Request, Respond};
 
 use super::StateMap;
-
-/// The default exchange is indicated by the empty string in AMQP.
-const DEFAULT_EXCHANGE: &str = "";
 
 /// Handler tasks are the async functions that are run in the tokio tasks to perform handlers.
 ///
@@ -124,7 +121,7 @@ where
 
         let publish = channel
             .basic_publish(
-                DEFAULT_EXCHANGE,
+                Exchange::default().name(),
                 reply_to.as_str(),
                 BasicPublishOptions::default(),
                 &bytes_response,
@@ -186,9 +183,6 @@ pub(super) struct TaskFactory {
 }
 
 impl TaskFactory {
-    /// The in-built direct exchange.
-    const DIRECT_EXCHANGE: &'static str = "amq.direct";
-
     /// Constructs a new task factory from the given routing key and handler.
     pub(super) fn new<H, Args, Res>(
         routing_key: String,
@@ -241,7 +235,7 @@ impl TaskFactory {
         channel
             .queue_bind(
                 &self.routing_key,
-                Self::DIRECT_EXCHANGE,
+                self.queue_config.exchange.name(),
                 &self.routing_key,
                 Default::default(),
                 Default::default(),

--- a/kanin/src/app/task.rs
+++ b/kanin/src/app/task.rs
@@ -11,7 +11,7 @@ use lapin::{
 };
 use log::{debug, error, warn};
 
-use crate::{queue_config::Exchange, Handler, QueueConfig, Request, Respond};
+use crate::{Handler, QueueConfig, Request, Respond};
 
 use super::StateMap;
 
@@ -121,7 +121,7 @@ where
 
         let publish = channel
             .basic_publish(
-                Exchange::default().name(),
+                QueueConfig::DEFAULT_EXCHANGE,
                 reply_to.as_str(),
                 BasicPublishOptions::default(),
                 &bytes_response,
@@ -235,7 +235,7 @@ impl TaskFactory {
         channel
             .queue_bind(
                 &self.routing_key,
-                self.queue_config.exchange.name(),
+                &self.queue_config.exchange,
                 &self.routing_key,
                 Default::default(),
                 Default::default(),

--- a/kanin/src/queue_config.rs
+++ b/kanin/src/queue_config.rs
@@ -82,7 +82,7 @@ impl QueueConfig {
 impl Default for QueueConfig {
     fn default() -> Self {
         Self {
-            exchange: Self::DEFAULT_EXCHANGE.to_string(),
+            exchange: Self::DIRECT_EXCHANGE.to_string(),
             prefetch: Self::DEFAULT_PREFETCH,
             options: QueueDeclareOptions {
                 auto_delete: true,

--- a/kanin/src/queue_config.rs
+++ b/kanin/src/queue_config.rs
@@ -34,7 +34,7 @@ impl QueueConfig {
         Default::default()
     }
 
-    /// Sets the exchange of the handler.
+    /// Sets the exchange of the handler. Defaults to the direct exchange, [`QueueConfig::DIRECT_EXCHANGE`].
     pub fn with_exchange(mut self, exchange: impl Into<String>) -> Self {
         self.exchange = exchange.into();
         self


### PR DESCRIPTION
Adds an option to QueueConfig that allows you to set the durable flag on the queue.

Also adds the ability to specify the exchange to bind to when configuring a handler. Only adds support for the topic exchange so far.

I'm not 100% clear on the AMQP implications of this but it is believed this is required for event handlers.