### PR TITLE
Add app ip extractor

### DIFF
--- a/kanin/Cargo.toml
+++ b/kanin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanin"
-version = "0.25.1"
+version = "0.26.0"
 edition = "2021"
 authors = ["Victor Nordam Suadicani <v.n.suadicani@gmail.com>"]
 description = "An RPC microservice framework for AMQP, protobuf and Rust built on lapin (https://github.com/amqp-rs/lapin)."

--- a/kanin/Cargo.toml
+++ b/kanin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanin"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 authors = ["Victor Nordam Suadicani <v.n.suadicani@gmail.com>"]
 description = "An RPC microservice framework for AMQP, protobuf and Rust built on lapin (https://github.com/amqp-rs/lapin)."

--- a/kanin/src/extract.rs
+++ b/kanin/src/extract.rs
@@ -1,5 +1,6 @@
 //! Interface for types that can extract themselves from requests.
 
+mod app_id;
 mod message;
 mod req_id;
 mod state;
@@ -11,6 +12,7 @@ use lapin::{acker::Acker, message::Delivery, Channel};
 
 use crate::{error::HandlerError, Request};
 
+pub use app_id::AppId;
 pub use message::Msg;
 pub use req_id::ReqId;
 pub use state::State;

--- a/kanin/src/extract/app_id.rs
+++ b/kanin/src/extract/app_id.rs
@@ -1,0 +1,30 @@
+//! App IDs defined in the request.
+
+use std::convert::Infallible;
+
+use async_trait::async_trait;
+
+use crate::{Extract, Request};
+
+/// App ID extracted from the properties of the incoming request. Notice that this is already
+/// logged as part of handling the request.
+#[derive(Debug, Clone)]
+pub struct AppId(pub Option<String>);
+
+impl AppId {
+    /// Returns the underlying `app_id` if it was present in the request. Alternatively the
+    /// `default` is returned.
+    pub fn unwrap_or<'a>(&'a self, default: &'a str) -> &'a str {
+        self.0.as_deref().unwrap_or(default)
+    }
+}
+
+#[async_trait]
+impl Extract for AppId {
+    type Error = Infallible;
+
+    async fn extract(req: &mut Request) -> Result<Self, Self::Error> {
+        let app_id = req.app_id().map(|app_id| app_id.to_string());
+        Ok(Self(app_id))
+    }
+}

--- a/kanin/src/extract/app_id.rs
+++ b/kanin/src/extract/app_id.rs
@@ -11,14 +11,6 @@ use crate::{Extract, Request};
 #[derive(Debug, Clone)]
 pub struct AppId(pub Option<String>);
 
-impl AppId {
-    /// Returns the underlying `app_id` if it was present in the request. Alternatively the
-    /// `default` is returned.
-    pub fn unwrap_or<'a>(&'a self, default: &'a str) -> &'a str {
-        self.0.as_deref().unwrap_or(default)
-    }
-}
-
 #[async_trait]
 impl Extract for AppId {
     type Error = Infallible;


### PR DESCRIPTION
This is a generally useful thing to be able to easily get out of a request and even though it is possible to do currently (via the delivery) it is more cumbersome than it has to be. This PR makes it straight forward by having a simple wrapper that implements the `Extract` trait.

```rs
use kanin::extract::AppId;
async fn my_handler(AppId(app_id): AppId) {
    dbg!(app_id);
}
```