### PR TITLE
Make req_id's amqpvalue public

### DIFF
--- a/kanin/src/extract/req_id.rs
+++ b/kanin/src/extract/req_id.rs
@@ -16,7 +16,7 @@ use crate::{Extract, Request};
 /// to be traced between different services by propagating the request IDs when calling other services.
 /// This type implements [`Extract`], so it can be used in handlers.
 #[derive(Debug, Clone)]
-pub struct ReqId(AMQPValue);
+pub struct ReqId(pub AMQPValue);
 
 impl ReqId {
     /// Create a new [`ReqId`] as a random UUID.


### PR DESCRIPTION
Currently there is no way to get the actual Lapin value out of the `ReqId`. Your only option, if you wish to manually pass it on to message being published, is to call `.to_string()` on it and then wrap it in another:
```rs
AMQPValue::LongString(LongString::from(req_id.to_string()))
```

This PR just makes it public, so you can get the actual value out.

Notice: I did not bump the version, since there is another pending PR.