### PR TITLE
Arc-less state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Check format
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --check --all
+      run: cargo fmt --check --all
 
   # Ensures that there are no lint warnings or type errors.
   lint:
@@ -26,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install Protobuf (needed by prost)
       run: |
@@ -40,10 +37,7 @@ jobs:
         rm -r /tmp/protoc
 
     - name: Lint
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --workspace --all-targets -- --deny warnings
+      run: cargo clippy --workspace --all-targets -- --deny warnings
 
   # Runs cargo deny, an auditing tool and dependency checker, among other things. See https://github.com/EmbarkStudios/cargo-deny
   audit:
@@ -51,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Audit
       uses: EmbarkStudios/cargo-deny-action@v1
@@ -62,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install Protobuf (needed by prost)
       run: |
@@ -76,10 +70,7 @@ jobs:
         rm -r /tmp/protoc
 
     - name: Install just
-      uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: just
+      run: cargo install just
 
     - name: Run tests
       run: just test

--- a/kanin/Cargo.toml
+++ b/kanin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanin"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 authors = ["Victor Nordam Suadicani <v.n.suadicani@gmail.com>"]
 description = "An RPC microservice framework for AMQP, protobuf and Rust built on lapin (https://github.com/amqp-rs/lapin)."

--- a/kanin/src/app/task.rs
+++ b/kanin/src/app/task.rs
@@ -171,22 +171,25 @@ async fn handle_request<H, Args, Res>(
         // Even worse, the response we produced is non-empty - it was probably meant to be received by someone!
         // In this case, we warn. Empty responses may be produced by non-responding handlers, which is fine.
         (true, None) if !bytes_response.is_empty() => {
-            let handler = std::any::type_name::<H>();
             let req_props = properties
                 .map(|p| format!("{p:?}"))
                 .unwrap_or_else(|| "<None>".into());
 
-            warn!("Received non-empty message from handler {handler:?} but the request did not contain a `reply_to` property, so no reply could be published (all properties: {req_props}, elapsed={elapsed:?}).");
+            warn!("Received non-empty message from handler {handler_name:?} but the request did not contain a `reply_to` property, so no reply could be published (all properties: {req_props}, elapsed={elapsed:?}).");
         }
         // We are supposed to reply, but the request did not have a reply_to.
         // However we produced an empty response, so it's not like the caller missed any information.
         (true, None) => {
-            info!("Handler finished (empty, should_reply = true, elapsed={elapsed:?})");
+            info!(
+                "Handler {handler_name} finished (empty, should_reply = true, elapsed={elapsed:?})",
+            );
         }
         // We are not supposed to reply so we won't.
         (false, _) => {
             let len = bytes_response.len();
-            info!("Handler finished ({len} bytes, should_reply = false, elapsed={elapsed:?}).");
+            info!(
+                "Handler {handler_name} finished ({len} bytes, should_reply = false, elapsed={elapsed:?}).",
+            );
         }
     };
 

--- a/kanin/src/extract/req_id.rs
+++ b/kanin/src/extract/req_id.rs
@@ -15,12 +15,12 @@ use crate::{Extract, Request};
 /// Request IDs allow concurrent logs to be associated with a unique request. It can also enable requests
 /// to be traced between different services by propagating the request IDs when calling other services.
 /// This type implements [`Extract`], so it can be used in handlers.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ReqId(pub AMQPValue);
 
 impl ReqId {
     /// Create a new [`ReqId`] as a random UUID.
-    fn new() -> Self {
+    pub fn new() -> Self {
         let uuid = Uuid::new_v4();
         let amqp_value = AMQPValue::LongString(LongString::from(uuid.to_string()));
         Self(amqp_value)
@@ -38,6 +38,12 @@ impl ReqId {
         };
 
         Self(req_id.clone())
+    }
+}
+
+impl Default for ReqId {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/kanin/src/extract/state.rs
+++ b/kanin/src/extract/state.rs
@@ -1,7 +1,5 @@
 //! Allows extracting app state.
 
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use derive_more::{Deref, DerefMut};
 use tracing::error;
@@ -13,9 +11,9 @@ use crate::{error::ServerError, Extract, HandlerError, Request};
 ///
 /// This implements `Deref` and `DerefMut` to the inner type.
 #[derive(Debug, Deref, DerefMut)]
-pub struct State<T>(pub Arc<T>);
+pub struct State<T>(pub T);
 
-impl<T> Clone for State<T> {
+impl<T: Clone> Clone for State<T> {
     fn clone(&self) -> Self {
         Self(self.0.clone())
     }
@@ -23,16 +21,16 @@ impl<T> Clone for State<T> {
 
 /// Extract implementation for app state.
 #[async_trait]
-impl<T: 'static + Send + Sync> Extract for State<T> {
+impl<T: Clone + Send + Sync + 'static> Extract for State<T> {
     type Error = HandlerError;
 
     async fn extract(req: &mut Request) -> Result<Self, Self::Error> {
-        match req.state::<State<T>>() {
+        match req.state::<T>() {
             None => {
                 error!("Attempted to retrieve state of type {}, but that type has not been added to the app state. Add it with `app.state(...)`", std::any::type_name::<T>());
                 Err(HandlerError::Internal(ServerError::StateNotFound))
             }
-            Some(t) => Ok(t.clone()),
+            Some(t) => Ok(State(t.clone())),
         }
     }
 }

--- a/kanin/src/handler.rs
+++ b/kanin/src/handler.rs
@@ -47,7 +47,7 @@ macro_rules! impl_handler {
                     let $ty = match $ty::extract(req).await {
                         Ok(value) => value,
                         Err(error) => {
-                            tracing::error!("{error}");
+                            tracing::error!("Failed to extract {}: {error}", std::any::type_name::<$ty>());
                             return Res::from_error(error);
                         }
                     };

--- a/kanin/src/handler_config.rs
+++ b/kanin/src/handler_config.rs
@@ -32,13 +32,13 @@ impl HandlerConfig {
 
     /// The default exchange is indicated by the empty string in AMQP.
     /// Note that the default exchange is actually just a direct exchange with no name.
-    pub const DEFAULT_EXCHANGE: &str = "";
+    pub const DEFAULT_EXCHANGE: &'static str = "";
 
     /// The direct exchange. See <`https://www.rabbitmq.com/tutorials/tutorial-four-python.html`> for more information.
-    pub const DIRECT_EXCHANGE: &str = "amq.direct";
+    pub const DIRECT_EXCHANGE: &'static str = "amq.direct";
 
     /// The topic exchange. See <`https://www.rabbitmq.com/tutorials/tutorial-five-python.html`> for more information.
-    pub const TOPIC_EXCHANGE: &str = "amq.topic";
+    pub const TOPIC_EXCHANGE: &'static str = "amq.topic";
 
     /// Creates a new default QueueConfig.
     pub fn new() -> Self {

--- a/kanin/src/request.rs
+++ b/kanin/src/request.rs
@@ -36,8 +36,8 @@ impl Request {
 
     /// Returns the app state for the given type.
     /// Returns `None` if the app state has not been added to the app.
-    pub fn state<T: 'static + Send + Sync>(&self) -> Option<&T> {
-        self.state.get()
+    pub fn state<T: Clone + Send + Sync + 'static>(&self) -> Option<T> {
+        self.state.get().cloned()
     }
 
     /// Returns a reference to the [`Channel`] the message was delivered on.


### PR DESCRIPTION
This avoids double indirection when the state is already wrapped in an arc. This is the case for database connection pools for instance.