### PR TITLE
Respond with content-type octet-stream

### DIFF
--- a/kanin/Cargo.toml
+++ b/kanin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanin"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 authors = ["Victor Nordam Suadicani <v.n.suadicani@gmail.com>"]
 description = "An RPC microservice framework for AMQP, protobuf and Rust built on lapin (https://github.com/amqp-rs/lapin)."

--- a/kanin/src/app/task.rs
+++ b/kanin/src/app/task.rs
@@ -6,7 +6,7 @@ use futures::{stream::FuturesUnordered, Future, StreamExt};
 use lapin::{
     acker::Acker,
     options::{BasicAckOptions, BasicConsumeOptions, BasicPublishOptions, BasicQosOptions},
-    types::FieldTable,
+    types::{FieldTable, ShortString},
     BasicProperties, Channel, Connection, Consumer,
 };
 use tracing::{debug, error, info, info_span, trace, warn, Instrument};
@@ -144,6 +144,9 @@ async fn handle_request<H, S, Args, Res>(
                     bytes_response.len()
                 );
             }
+
+            // Since we expect the response to be protobuf, we set the content type to octet-stream. This is important for thin-layer.
+            props = props.with_content_type(ShortString::from("application/octet-stream"));
 
             let publish = channel
                 .basic_publish(

--- a/kanin/src/app/task.rs
+++ b/kanin/src/app/task.rs
@@ -145,7 +145,7 @@ async fn handle_request<H, S, Args, Res>(
                 );
             }
 
-            // Since we expect the response to be protobuf, we set the content type to octet-stream. This is important for thin-layer.
+            // Since we expect the response to be encoded Protobuf, we set the content type to octet-stream.
             props = props.with_content_type(ShortString::from("application/octet-stream"));
 
             let publish = channel


### PR DESCRIPTION
We need to set the content-type head to octet-stream to interact properly with thin-layer