### PR TITLE
Remove delivery extraction, enable easy consumer timeout and concurrent task creation

### DIFF
--- a/kanin/Cargo.toml
+++ b/kanin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanin"
-version = "0.28.1"
+version = "0.29.0"
 edition = "2021"
 authors = ["Victor Nordam Suadicani <v.n.suadicani@gmail.com>"]
 description = "An RPC microservice framework for AMQP, protobuf and Rust built on lapin (https://github.com/amqp-rs/lapin)."
@@ -13,10 +13,10 @@ readme = "../README.md"
 
 [dependencies]
 # Derive macros for traits in kanin.
-kanin_derive = "0.6.0"
+kanin_derive = "0.7.0"
 
 # Lower level AMQP framework.
-lapin = "2.1.0"
+lapin = "2.3.1"
 
 # Generalized tracing framework.
 tracing = "0.1.37"

--- a/kanin/src/error.rs
+++ b/kanin/src/error.rs
@@ -23,16 +23,6 @@ pub enum HandlerError {
     /// Errors due to invalid requests.
     #[error("Invalid Request: {0:#}")]
     InvalidRequest(RequestError),
-
-    /// Internal server errors that are not the fault of clients.
-    #[error("Internal Server Error: {0:#}")]
-    Internal(ServerError),
-}
-
-impl HandlerError {
-    /// Convenient const for this otherwise long error.
-    pub const DELIVERY_ALREADY_EXTRACTED: Self =
-        Self::Internal(ServerError::DeliveryAlreadyExtracted);
 }
 
 /// All the ways a request might be invalid.
@@ -43,14 +33,6 @@ pub enum RequestError {
     /// This error is left as an opaque error as that is what is provided by [`prost`].
     #[error("Message could not be decoded into the required type: {0:#}")]
     DecodeError(DecodeError),
-}
-
-/// Errors due to bad configuration or usage from the server-side.
-#[derive(Debug, ThisError)]
-pub enum ServerError {
-    /// A handler attempted to extract the delivery of a message twice.
-    #[error("The delivery was already extracted from the request and could not be accessed")]
-    DeliveryAlreadyExtracted,
 }
 
 /// Types that may be constructed from errors.
@@ -100,7 +82,6 @@ impl FromError<HandlerError> for () {
             HandlerError::InvalidRequest(e) => {
                 warn!("Listener handler received an invalid request: {e:#}")
             }
-            HandlerError::Internal(e) => error!("Internal error on listener handler: {e:#}"),
         }
     }
 }

--- a/kanin/src/extract.rs
+++ b/kanin/src/extract.rs
@@ -5,17 +5,17 @@ mod message;
 mod req_id;
 mod state;
 
-use std::{convert::Infallible, error::Error};
-
-use async_trait::async_trait;
-use lapin::{acker::Acker, message::Delivery, Channel};
-
-use crate::{error::HandlerError, Request};
-
 pub use app_id::AppId;
 pub use message::Msg;
 pub use req_id::ReqId;
 pub use state::State;
+
+use std::{convert::Infallible, error::Error};
+
+use async_trait::async_trait;
+use lapin::{acker::Acker, Channel};
+
+use crate::Request;
 
 /// A trait for types that can be extracted from [requests](`Request`).
 ///
@@ -30,36 +30,18 @@ pub trait Extract<S>: Sized {
     async fn extract(req: &mut Request<S>) -> Result<Self, Self::Error>;
 }
 
-/// Note that when you extract the [`Delivery`], the handler itself must acknowledge the request.
-/// Kanin *will not* acknowledge the request for you in this case.
-#[async_trait]
-impl<S> Extract<S> for Delivery
-where
-    S: Send + Sync,
-{
-    type Error = HandlerError;
-
-    async fn extract(req: &mut Request<S>) -> Result<Self, Self::Error> {
-        req.delivery
-            .take()
-            .ok_or(HandlerError::DELIVERY_ALREADY_EXTRACTED)
-    }
-}
-
 /// Note that when you extract the [`Acker`], the handler itself must acknowledge the request.
 /// kanin *will not* acknowledge the request for you in this case.
+// TODO: This implementation is quite hacky and should probably be removed.
 #[async_trait]
 impl<S> Extract<S> for Acker
 where
     S: Send + Sync,
 {
-    type Error = HandlerError;
+    type Error = Infallible;
 
     async fn extract(req: &mut Request<S>) -> Result<Self, Self::Error> {
-        req.delivery
-            .as_mut()
-            .ok_or(HandlerError::DELIVERY_ALREADY_EXTRACTED)
-            .map(|d| std::mem::take(&mut d.acker))
+        Ok(std::mem::take(&mut req.delivery.acker))
     }
 }
 

--- a/kanin/src/extract/message.rs
+++ b/kanin/src/extract/message.rs
@@ -20,12 +20,6 @@ where
     type Error = HandlerError;
 
     async fn extract(req: &mut Request<S>) -> Result<Self, Self::Error> {
-        match &req.delivery {
-            None => Err(HandlerError::DELIVERY_ALREADY_EXTRACTED),
-            Some(d) => {
-                let data: &[u8] = &d.data;
-                Ok(Msg(D::decode(data)?))
-            }
-        }
+        Ok(Msg(D::decode(&req.delivery.data[..])?))
     }
 }

--- a/kanin/src/extract/req_id.rs
+++ b/kanin/src/extract/req_id.rs
@@ -82,6 +82,6 @@ where
     type Error = Infallible;
 
     async fn extract(req: &mut Request<S>) -> Result<Self, Self::Error> {
-        Ok(req.req_id.clone())
+        Ok(req.req_id().clone())
     }
 }

--- a/kanin/src/handler_config.rs
+++ b/kanin/src/handler_config.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use lapin::options::QueueDeclareOptions;
-use lapin::types::{AMQPValue, FieldTable, ShortString};
+use lapin::types::{AMQPValue, FieldTable, LongString, ShortString};
 
 /// Detailed configuration of a handler.
 #[derive(Clone, Debug)]
@@ -45,7 +45,7 @@ impl HandlerConfig {
         Default::default()
     }
 
-    /// Sets the exchange of the handler. Defaults to the direct exchange, [`HandlerConfig::DIRECT_EXCHANGE`].
+    /// Sets the queue name. Defaults to the same as the routing key.
     pub fn with_queue(mut self, queue: impl Into<String>) -> Self {
         self.queue = Some(queue.into());
         self
@@ -106,7 +106,10 @@ impl HandlerConfig {
     }
 
     /// Sets the `x-dead-letter-exchange` argument on the queue. See also [RabbitMQ's documentation](https://www.rabbitmq.com/dlx.html).
-    pub fn with_dead_letter_exchange(mut self, dead_letter_exchange: String) -> Self {
+    pub fn with_dead_letter_exchange(
+        mut self,
+        dead_letter_exchange: impl Into<LongString>,
+    ) -> Self {
         self.arguments.insert(
             "x-dead-letter-exchange".into(),
             AMQPValue::LongString(dead_letter_exchange.into()),
@@ -115,10 +118,22 @@ impl HandlerConfig {
     }
 
     /// Sets the `x-dead-letter-routing-key` argument on the queue. See also [RabbitMQ's documentation](https://www.rabbitmq.com/dlx.html).
-    pub fn with_dead_letter_routing_key(mut self, dead_letter_routing_key: String) -> Self {
+    pub fn with_dead_letter_routing_key(
+        mut self,
+        dead_letter_routing_key: impl Into<LongString>,
+    ) -> Self {
         self.arguments.insert(
             "x-dead-letter-routing-key".into(),
             AMQPValue::LongString(dead_letter_routing_key.into()),
+        );
+        self
+    }
+
+    /// Sets the `x-consumer-timeout` argument on the queue. See also [RabbitMQ's documentation](https://www.rabbitmq.com/consumers.html).
+    pub fn with_consumer_timeout(mut self, consumer_timeout: impl Into<LongString>) -> Self {
+        self.arguments.insert(
+            "x-consumer-timeout".into(),
+            AMQPValue::LongString(consumer_timeout.into()),
         );
         self
     }

--- a/kanin/src/lib.rs
+++ b/kanin/src/lib.rs
@@ -13,7 +13,6 @@
 //! #         #[prost(string, tag="1")]
 //! #         pub error: ::prost::alloc::string::String,
 //! #     }
-//! #     #[derive(kanin::FromError)]
 //! #     #[derive(Clone, PartialEq, ::prost::Message)]
 //! #     pub struct InternalError {
 //! #         #[prost(string, tag="1")]

--- a/kanin/src/request.rs
+++ b/kanin/src/request.rs
@@ -17,9 +17,9 @@ pub struct Request<S> {
     channel: Channel,
     /// Request ID. This is a unique ID for every request. Either a newly created UUID or whatever
     /// is found in the `req_id` header of the incoming AMQP message.
-    pub(crate) req_id: ReqId,
+    req_id: ReqId,
     /// The message delivery.
-    pub(crate) delivery: Option<Delivery>,
+    pub(crate) delivery: Delivery,
 }
 
 impl<S> Request<S> {
@@ -29,8 +29,18 @@ impl<S> Request<S> {
             state,
             channel,
             req_id: ReqId::from_delivery(&delivery),
-            delivery: Some(delivery),
+            delivery,
         }
+    }
+
+    /// Returns a reference to the request ID of this request.
+    pub fn req_id(&self) -> &ReqId {
+        &self.req_id
+    }
+
+    /// Returns a reference to the delivery of this request.
+    pub fn delivery(&self) -> &Delivery {
+        &self.delivery
     }
 
     /// Returns the app state for the given type.
@@ -47,14 +57,15 @@ impl<S> Request<S> {
     }
 
     /// Returns the AMQP properties of the request, unless the request was already extracted.
-    pub fn properties(&self) -> Option<&AMQPProperties> {
-        self.delivery.as_ref().map(|d| &d.properties)
+    pub fn properties(&self) -> &AMQPProperties {
+        &self.delivery.properties
     }
 
     /// Returns the `app_id` AMQP property of the request.
     pub fn app_id(&self) -> Option<&str> {
         self.properties()
-            .and_then(|p| p.app_id().as_ref())
+            .app_id()
+            .as_ref()
             .map(|app_id| app_id.as_str())
     }
 }

--- a/kanin/src/response.rs
+++ b/kanin/src/response.rs
@@ -1,4 +1,6 @@
 //! AMQP responses.
+//!
+//! Any type that implements [`Respond`] can be used as the return type of a handler.
 
 use std::fmt;
 
@@ -10,7 +12,7 @@ use prost::Message;
 /// However, the type must also be able to be displayed for debugging purposes
 /// and be sent across threads during processing.
 pub trait Respond: fmt::Debug + Send {
-    /// Creates the bytes payload of this value.
+    /// Creates the bytes payload of the response.
     fn respond(self) -> Vec<u8>;
 }
 

--- a/kanin/src/tests/send_recv.rs
+++ b/kanin/src/tests/send_recv.rs
@@ -1,9 +1,11 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    convert::Infallible,
+    sync::{Arc, Mutex},
+};
 
 use async_trait::async_trait;
 use futures::future::join_all;
 use lapin::{
-    message::Delivery,
     options::BasicPublishOptions,
     types::{AMQPValue, FieldTable},
     BasicProperties, Channel,
@@ -33,7 +35,6 @@ impl FromError<HandlerError> for MyResponse {
     fn from_error(error: HandlerError) -> Self {
         match error {
             HandlerError::InvalidRequest(e) => MyResponse(format!("Invalid request: {e:#?}")),
-            HandlerError::Internal(e) => MyResponse(format!("Internal server error: {e:#?}")),
         }
     }
 }
@@ -43,13 +44,12 @@ impl<S> Extract<S> for MyResponse
 where
     S: Send + Sync,
 {
-    type Error = HandlerError;
+    type Error = Infallible;
 
     async fn extract(req: &mut Request<S>) -> Result<Self, Self::Error> {
-        match &req.delivery {
-            None => Err(HandlerError::DELIVERY_ALREADY_EXTRACTED),
-            Some(d) => Ok(MyResponse(String::from_utf8_lossy(&d.data).to_string())),
-        }
+        Ok(MyResponse(
+            String::from_utf8_lossy(&req.delivery().data).to_string(),
+        ))
     }
 }
 
@@ -72,11 +72,6 @@ async fn handler_channel(_channel: Channel) -> MyResponse {
     MyResponse("handler_channel".into())
 }
 
-async fn handler_delivery(_delivery: Delivery) -> MyResponse {
-    SYNC.get().unwrap().send(()).await.unwrap();
-    MyResponse("handler_delivery".into())
-}
-
 async fn handler_req_id(req_id: ReqId) -> MyResponse {
     assert_eq!(req_id.to_string(), "abc");
     SYNC.get().unwrap().send(()).await.unwrap();
@@ -89,7 +84,7 @@ async fn handler_app_id(AppId(app_id): AppId) -> MyResponse {
     MyResponse("handler_app_id".into())
 }
 
-async fn handler_two_extractors(_channel: Channel, _delivery: Delivery) -> MyResponse {
+async fn handler_two_extractors(_channel: Channel, _app_id: AppId) -> MyResponse {
     SYNC.get().unwrap().send(()).await.unwrap();
     MyResponse("handler_two_extractors".into())
 }
@@ -145,7 +140,6 @@ async fn it_receives_various_messages_and_works_as_expected() {
     let send_app = App::new(send_state.clone())
         .handler("handler", handler)
         .handler("handler_channel", handler_channel)
-        .handler("handler_delivery", handler_delivery)
         .handler("handler_req_id", handler_req_id)
         .handler("handler_app_id", handler_app_id)
         .handler("handler_two_extractors", handler_two_extractors)
@@ -202,9 +196,6 @@ async fn it_receives_various_messages_and_works_as_expected() {
         recv.recv().await.unwrap();
         recv.recv().await.unwrap();
         send_msg("handler_channel", "handler_message_reply_to").await;
-        recv.recv().await.unwrap();
-        recv.recv().await.unwrap();
-        send_msg("handler_delivery", "handler_message_reply_to").await;
         recv.recv().await.unwrap();
         recv.recv().await.unwrap();
         send_msg("handler_req_id", "handler_message_reply_to").await;

--- a/kanin/tests/protobuf.rs
+++ b/kanin/tests/protobuf.rs
@@ -29,7 +29,7 @@ mod generated {
 
     /// An internal error. This is used for any error that can't be handled in any other way.
     /// Consider it a last resort when no other more specific error can be returned.
-    #[derive(FromError, Clone, PartialEq, ::prost::Message)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct InternalError {
         /// The source is an a1pp ID that specifies the service in which the error originated.
         #[prost(string, tag = "1")]

--- a/kanin_derive/Cargo.toml
+++ b/kanin_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanin_derive"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["Victor Nordam Suadicani <v.n.suadicani@gmail.com>"]
 description = "Derive macros for kanin"

--- a/kanin_derive/src/from_error.rs
+++ b/kanin_derive/src/from_error.rs
@@ -4,15 +4,12 @@ use syn::{punctuated::Punctuated, token::Comma, Field, Ident, Variant};
 
 /// Derives the FromError trait for a struct with named fields.
 ///
-/// If the struct is called `InvalidRequest` or `InternalError`, they will be handled
-/// specially by implementing FromError for the appropriate kanin error types.
+/// If the struct is called "InvalidRequest", it will be handled in a special way.
 pub(crate) fn derive_named(name: Ident, fields: Punctuated<Field, Comma>) -> TokenStream {
     let name_s = name.to_string();
 
     if name_s.contains("InvalidRequest") {
         return derive_invalid_request(name);
-    } else if name_s.contains("InternalError") {
-        return derive_internal_error(name);
     }
 
     let num_fields = fields.len();
@@ -38,20 +35,6 @@ fn derive_invalid_request(name: Ident) -> TokenStream {
             fn from_error(error: ::kanin::error::RequestError) -> Self {
                 #name {
                     error: format!("{:#}", error)
-                }
-            }
-        }
-    }
-    .into()
-}
-
-fn derive_internal_error(name: Ident) -> TokenStream {
-    quote! {
-        impl ::kanin::error::FromError<::kanin::error::ServerError> for #name {
-            fn from_error(error: ::kanin::error::ServerError) -> Self {
-                #name {
-                    error: format!("{:#}", error),
-                    source: env!("CARGO_PKG_NAME").to_string(),
                 }
             }
         }
@@ -93,18 +76,12 @@ fn derive_named_newtype(name: Ident, field_name: &Ident) -> TokenStream {
     .into()
 }
 
-/// Derives the FromError trait for an enum with InvalidRequest and InternalError variants.
+/// Derives the FromError trait for an enum with InvalidRequest variants.
 pub(crate) fn derive_enum(name: Ident, variants: Punctuated<Variant, Comma>) -> TokenStream {
     let invalid_request_name = &variants
         .iter()
         .find(|v| v.ident.to_string().contains("InvalidRequest"))
         .expect("enum missing a variant containing \"InvalidRequest\"")
-        .ident;
-
-    let internal_error_name = &variants
-        .iter()
-        .find(|v| v.ident.to_string().contains("InternalError"))
-        .expect("enum missing a variant containing \"InternalError\"")
         .ident;
 
     quote! {
@@ -113,9 +90,6 @@ pub(crate) fn derive_enum(name: Ident, variants: Punctuated<Variant, Comma>) -> 
                 match error {
                     ::kanin::HandlerError::InvalidRequest(e) => {
                         Self::#invalid_request_name(::kanin::error::FromError::from_error(e))
-                    },
-                    ::kanin::HandlerError::Internal(e) => {
-                        Self::#internal_error_name(::kanin::error::FromError::from_error(e))
                     },
                 }
             }

--- a/minimal_example/build.rs
+++ b/minimal_example/build.rs
@@ -5,7 +5,6 @@ fn main() {
         // as a return type from a handler. So we just list them here.
         // These are paths into the .proto file, not the generated Rust code.
         .type_attribute("InvalidRequest", "#[derive(kanin::FromError)]")
-        .type_attribute("InternalError", "#[derive(kanin::FromError)]")
         .type_attribute("EchoResponse", "#[derive(kanin::FromError)]")
         .type_attribute("EchoResponse.response", "#[derive(kanin::FromError)]")
         .compile_protos(&["src/protobuf/echo.proto"], &["src"])


### PR DESCRIPTION
- Removes delivery extraction. This makes other extractors simpler and removes the possibility of many of them failing.
- Adds a convenience method to set the `x-consumer-timeout` argument on queues.
- Starts tasks concurrently rather one at a time for faster startup time.