### PR TITLE
Reintroduce acker

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @issuu/platypus
+* @issuu/backend

--- a/kanin/Cargo.toml
+++ b/kanin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanin"
-version = "0.32.0"
+version = "0.32.1"
 edition = "2021"
 authors = ["Victor Nordam Suadicani <v.n.suadicani@gmail.com>"]
 description = "An RPC microservice framework for AMQP, protobuf and Rust built on lapin (https://github.com/amqp-rs/lapin)."

--- a/kanin/src/app.rs
+++ b/kanin/src/app.rs
@@ -179,7 +179,7 @@ impl<S> App<S> {
     /// On connection errors, the app will attempt to gracefully shutdown.
     ///
     /// # Panics
-    /// Panics in your handlers does not cause the app to shutdown. Requests will be nacked in this case..
+    /// Panics in your handlers does not cause the app to shutdown. Requests will be rejected in this case.
     ///
     /// Internal panics inside kanin's code will however shut down the app. This shouldn't happen though (please report it if it does).
     #[inline]

--- a/kanin/src/app/task.rs
+++ b/kanin/src/app/task.rs
@@ -88,7 +88,10 @@ where
                     // We should only ever get to this point if the consumer is cancelled (see lapin::Consumer's implementation of Stream).
                     // We'll attempt a graceful shutdown in this case.
                     // We'll return the routing key - might be a help for the user to see which consumer got cancelled.
-                    None => break Err(Error::ConsumerCancelled(routing_key)),
+                    None => {
+                        error!("Consumer cancelled, attempting to gracefully shut down...");
+                        break Err(Error::ConsumerCancelled(routing_key));
+                    },
                 },
             };
 

--- a/kanin/src/extract.rs
+++ b/kanin/src/extract.rs
@@ -1,10 +1,12 @@
 //! Interface for types that can extract themselves from requests.
 
+mod acker;
 mod app_id;
 mod message;
 mod req_id;
 mod state;
 
+pub use acker::Acker;
 pub use app_id::AppId;
 pub use message::Msg;
 pub use req_id::ReqId;

--- a/kanin/src/extract/acker.rs
+++ b/kanin/src/extract/acker.rs
@@ -1,0 +1,74 @@
+//! Manual acknowledgement and rejection.
+
+use std::mem;
+
+use async_trait::async_trait;
+use lapin::{
+    acker::Acker as LapinAcker,
+    options::{BasicAckOptions, BasicRejectOptions},
+};
+
+use crate::{Extract, HandlerError, Request};
+
+/// An extractor that allows you manual control of acknowledgement and rejection of messages.
+///
+/// Note that when you extract an `Acker`, kanin _will not_ acknowledge the message for you.
+/// Neither will it reject the message if your handler panicks.
+///
+/// When you extract this, you are responsible for acknowledging or rejecting yourself.
+#[must_use = "You must call .ack or .reject in order to acknowledge or reject the message."]
+#[derive(Debug)]
+pub struct Acker(LapinAcker);
+
+impl Acker {
+    /// Acks the message that was received for this acker.
+    ///
+    /// # Errors
+    /// Returns `Err` on network failures.
+    // Note that since we consume the acker, it should not be possible to call this twice.
+    // Thus that error possibility is not listed.
+    pub async fn ack(self) -> Result<(), lapin::Error> {
+        self.0
+            .ack(BasicAckOptions {
+                // It does not make sense to use this flag with kanin, as it might interfere with handling of other previous messages.
+                multiple: false,
+            })
+            .await
+    }
+
+    /// Rejects the message that was received for this acker.
+    ///
+    /// # Errors
+    /// Returns `Err` on network failures.
+    // Note that since we consume the acker, it should not be possible to call this twice.
+    // Thus that error possibility is not listed.
+    pub async fn reject(self, options: BasicRejectOptions) -> Result<(), lapin::Error> {
+        self.0.reject(options).await
+    }
+}
+
+/// Extract implementation for the AMQP acker.
+#[async_trait]
+impl<S> Extract<S> for Acker
+where
+    S: Send + Sync,
+{
+    type Error = HandlerError;
+
+    async fn extract(req: &mut Request<S>) -> Result<Self, Self::Error> {
+        // This is quite a hacky way of taking the acker. We should improve this if/when lapin improves the interface.
+        // See also https://github.com/amqp-rs/lapin/issues/402.
+        let acker = mem::take(&mut req.delivery_mut().acker);
+
+        // The request will consider itself acked. It is up to the handler to actually ack the request.
+        req.acked = true;
+
+        if acker == LapinAcker::default() {
+            panic!(
+                "extracted acker was equal to the default acker - did you extract an acker twice?"
+            );
+        }
+
+        Ok(Acker(acker))
+    }
+}

--- a/kanin/src/extract/acker.rs
+++ b/kanin/src/extract/acker.rs
@@ -1,6 +1,6 @@
 //! Manual acknowledgement and rejection.
 
-use std::mem;
+use std::{convert::Infallible, mem};
 
 use async_trait::async_trait;
 use lapin::{
@@ -8,7 +8,7 @@ use lapin::{
     options::{BasicAckOptions, BasicRejectOptions},
 };
 
-use crate::{Extract, HandlerError, Request};
+use crate::{Extract, Request};
 
 /// An extractor that allows you manual control of acknowledgement and rejection of messages.
 ///
@@ -53,7 +53,7 @@ impl<S> Extract<S> for Acker
 where
     S: Send + Sync,
 {
-    type Error = HandlerError;
+    type Error = Infallible;
 
     async fn extract(req: &mut Request<S>) -> Result<Self, Self::Error> {
         // This is quite a hacky way of taking the acker. We should improve this if/when lapin improves the interface.


### PR DESCRIPTION
This API is kinda hacky but it is better than restructuring the whole system to get around it. If lapin improves the interface, we can maybe improve this as well.

Also changes the request span to be an error_span, so it shows up even when `kanin` is set to only log at the warn level, for instance.

Also updates the codeowners.